### PR TITLE
Make csvkit work with dateutil>2.2

### DIFF
--- a/csvkit-git/PKGBUILD
+++ b/csvkit-git/PKGBUILD
@@ -7,7 +7,8 @@ pkgdesc="A suite of utilities for converting to and working with CSV."
 arch=('any')
 url="http://csvkit.readthedocs.org"
 license=('MIT')
-depends=('python' 'python-nose>=1.1.2' 'python-xlrd>=0.9.2' 'python-dateutil>=2.0' 'python-sqlalchemy>=0.9.3' 'python-sphinx>=1.0.7' 'python-coverage>=3.5.1b1' 'python-openpyxl>=2.0.3' 'python-tox>=1.3' 'python-six>=1.6.1' 'python-jdcal')
+makedepends=('git')
+depends=('python' 'python-xlrd>=0.9.2' 'python-dateutil>=2.0' 'python-sqlalchemy>=0.9.3' 'python-openpyxl>=2.0.3' 'python-six>=1.6.1')
 makedepends=('git')
 md5sums=('SKIP')
 source=('csvkit::git://github.com/onyxfish/csvkit.git')

--- a/csvkit-git/PKGBUILD
+++ b/csvkit-git/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Mariusz Szczepańczyk <mszczepanczyk@gmail.com>
 
 pkgname=csvkit-git
-pkgver=0.8.0.r1.g36beb44
+pkgver=0.9.0.r44.g61b9c20
 pkgrel=1
 pkgdesc="A suite of utilities for converting to and working with CSV."
 arch=('any')

--- a/csvkit-git/PKGBUILD
+++ b/csvkit-git/PKGBUILD
@@ -18,9 +18,15 @@ pkgver() {
   git describe --long | sed -r 's/([^-]*-g)/r\1/;s/-/./g'
 }
 
+build() {
+  cd "$srcdir/csvkit"
+  # Quick and dirty fix until the author officially supports dateutil>=2.2
+  # (see https://github.com/onyxfish/csvkit/issues/370)
+  sed -i 's/python-dateutil==2.2/python-dateutil>=2.2/' setup.py
+}
+
 package() {
   cd "$srcdir/csvkit"
   python setup.py install --root="$pkgdir/"
 }
-
 


### PR DESCRIPTION
Although csvkit requires `dateutil==2.2`, it seems to work fine with higher versions as well. Thus, folks on AUR suggest patching installed sources which is kind of dirty, so I updated PKGBUILD.
